### PR TITLE
Add version to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,6 @@
   "dependencies": [],
   "codeowners": ["@VatzU","@demonday"],
   "requirements": ["polling","xmljson"],
+  "version": "1.0.0",
   "config_flow": false
 }


### PR DESCRIPTION
Otherwise it'll just say `Platform error: climate - Integration 'climote' not found.`

<img width="958" alt="Screenshot 2021-12-10 at 12 21 25" src="https://user-images.githubusercontent.com/625787/145573382-52fb2d3b-7a13-4da8-aa9f-156fff1e6527.png">
